### PR TITLE
Handle empty files correctly

### DIFF
--- a/low/data/reader.go
+++ b/low/data/reader.go
@@ -10,6 +10,9 @@ type Reader struct {
 }
 
 func NewReader(f *FullReader) (Reader, error) {
+	if f.fileSize == 0 && f.BlockNum() == 0 {
+		return Reader{f: f}, nil
+	}
 	dat, err := f.Block(0)
 	if err != nil {
 		return Reader{}, err

--- a/low/data/reader_test.go
+++ b/low/data/reader_test.go
@@ -1,0 +1,45 @@
+package data
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestNewReaderEmptyFullReader(t *testing.T) {
+	full := NewFullReader(bytes.NewReader(nil), nil, 4096, 0, 0, nil)
+
+	reader, err := NewReader(&full)
+	if err != nil {
+		t.Fatalf("NewReader() error = %v", err)
+	}
+
+	got, err := io.ReadAll(&reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("ReadAll() returned %d bytes, want 0", len(got))
+	}
+}
+
+func TestNewReaderPropagatesFirstBlockError(t *testing.T) {
+	tests := []struct {
+		name  string
+		sizes []uint32
+		want  string
+	}{
+		{name: "missing block", want: "invalid block index"},
+		{name: "truncated block", sizes: []uint32{1}, want: io.EOF.Error()},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			full := NewFullReader(bytes.NewReader(nil), nil, 4096, 1, 0, tt.sizes)
+
+			_, err := NewReader(&full)
+			if err == nil || err.Error() != tt.want {
+				t.Fatalf("NewReader() error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Empty files don’t have any data blocks or a fragment. `NewReader`
currently tries to load block zero anyway, so reading a valid empty file
fails with `invalid block index`.

This skips that initial block read only when the file is genuinely empty.
Malformed and truncated non-empty files still return their existing
errors.

## Reproduction

Create a small SquashFS image containing an empty file:

```sh
work=$(mktemp -d)
mkdir "$work/src"
mksquashfs "$work/src" "$work/empty.sqfs" \
  -noappend -no-progress -repro-time 0 -comp gzip \
  -p 'empty f 0644 0 0 true'
```

Then read it with:

```go
package main

import (
	"fmt"
	"io"
	"os"

	"github.com/CalebQ42/squashfs"
)

func main() {
	image, err := os.Open(os.Args[1])
	check(err)

	reader, err := squashfs.NewReader(image)
	check(err)

	file, err := reader.Open("empty")
	check(err)

	content, err := io.ReadAll(file)
	check(err)

	fmt.Printf("read %d bytes\n", len(content))
}

func check(err error) {
	if err != nil {
		fmt.Fprintln(os.Stderr, err)
		os.Exit(1)
	}
}
```

v1.4.1 fails with:

```text
invalid block index
exit status 1
```

With the fix in this PR, it returns:

```text
read 0 bytes
```

## Testing

- `go test -race ./low/data`
- The generated-image reproduction above
